### PR TITLE
使用方法v3更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Japanese messages for [react-admin](https://github.com/marmelab/react-admin).
 
-react-adminの日本語翻訳です。  
-直訳せず、読みさすさとシンプルさを優先した意訳をしています。  
+react-adminの日本語翻訳です。
+直訳せず、読みさすさとシンプルさを優先した意訳をしています。
 翻訳の提案がございましたら、お気軽に issue 頂ければ幸いです。
 
 ## インストール
@@ -33,9 +33,9 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 const messages = {
     ja: japaneseMessages
 };
-const i18nProvider = polyglotI18nProvider(locale => messages[locale]);
+const i18nProvider = polyglotI18nProvider(locale => messages[locale],"ja");
 
-<Admin locale="ja" i18nProvider={i18nProvider}>
+<Admin i18nProvider={i18nProvider}>
   ...
 </Admin>
 ```


### PR DESCRIPTION
> The Admin component does not accept a locale prop anymore as it is the i18nProvider provider responsibility. Pass the initial locale as second argument to polyglotI18nProvider instead of passing it to Admin
>
> https://github.com/marmelab/react-admin/blob/master/UPGRADE.md