### PR TITLE
fix: 「並び替え中」から「並び替える」へ

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ var messages = {
             logout: "ログアウト",
         },
         sort: {
-            sort_by: "%{field}を%{order}で並び替え中",
+            sort_by: "%{field}を%{order}で並び替える",
             ASC: "昇順",
             DESC: "降順",
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ const messages: Required<TranslationMessages> = {
 			logout: "ログアウト",
 		},
 		sort: {
-			sort_by: "%{field}を%{order}で並び替え中",
+			sort_by: "%{field}を%{order}で並び替える",
 			ASC: "昇順",
 			DESC: "降順",
 		},


### PR DESCRIPTION
https://github.com/marmelab/react-admin/issues/10182 
こちらで確認すると並び替え中ではなく並び替えを変更するという意図のようでした。