### PR TITLE
fix: adapt to the configuration changes in pnpm 11

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -19,7 +19,4 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
     - run: pnpm install --frozen-lockfile
-    - run: pnpm publish --tag=latest
-      env:
-        NPM_CONFIG_PROVENANCE: true
-        NPM_CONFIG_GIT_CHECKS: false
+    - run: pnpm publish --tag=latest --provenance --no-git-checks

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -19,7 +19,4 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
     - run: pnpm install --frozen-lockfile
-    - run: pnpm publish --tag=next
-      env:
-        NPM_CONFIG_PROVENANCE: true
-        NPM_CONFIG_GIT_CHECKS: false
+    - run: pnpm publish --tag=next --provenance --no-git-checks

--- a/package.json
+++ b/package.json
@@ -54,11 +54,6 @@
 	"type": "module",
 	"zshy": "./src/index.ts",
 	"packageManager": "pnpm@11.17.0",
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome"
-		]
-	},
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.cts",
 	"exports": {


### PR DESCRIPTION
## Summary

Publishing v5.13.0 failed. pnpm 11 no longer reads `npm_config_*` environment variables, so the options passed via `env:` in the publish workflows were silently ignored.

https://github.com/bicstone/ra-language-japanese/actions/runs/31258980749/job/93106707487

```
[ERR_PNPM_GIT_UNKNOWN_BRANCH] The Git HEAD may not attached to any branch,
but your "publish-branch" is set to "master|main".
```

## Cause

[pnpm 11](https://github.com/pnpm/pnpm/releases/tag/v11.0.0) contains this breaking change:

> pnpm no longer reads `npm_config_*` environment variables. Use `pnpm_config_*` environment variables instead.

Both of the following were therefore ignored:

| Variable | Intended effect | Actual result |
|---|---|---|
| `NPM_CONFIG_GIT_CHECKS: false` | Skip the publish-branch check | Ignored, so the check ran and failed |
| `NPM_CONFIG_PROVENANCE: true` | Publish with provenance | Ignored, so provenance was disabled |

The release workflow is triggered by `release: created` and checks out a tag, so `HEAD` is detached. pnpm's default `publish-branch` is `master|main`, and the check rejected the publish.

Provenance failed silently in the same way — had the git check passed, the package would have been published without provenance.

## Fix

Pass both as CLI flags, which are unaffected by the configuration changes in pnpm 11.

```diff
-    - run: pnpm publish --tag=latest
-      env:
-        NPM_CONFIG_PROVENANCE: true
-        NPM_CONFIG_GIT_CHECKS: false
+    - run: pnpm publish --tag=latest --provenance --no-git-checks
```

The same change is applied to `publish-next.yml`.

`--provenance` is not listed in `pnpm publish --help` but is documented in [the pnpm 11 CLI reference](https://pnpm.io/11.x/cli/publish) and is accepted by the CLI.

## Also: remove the obsolete `pnpm` field

pnpm 11 also stopped reading settings from the `pnpm` field of package.json, producing a warning on every command:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.onlyBuiltDependencies".
```

The setting is no longer needed either. `onlyBuiltDependencies` existed to allow `@biomejs/biome` to run build scripts, but Biome 2.x has no lifecycle scripts at all — it ships platform binaries through `optionalDependencies`:

```
version: 2.5.6
scripts: undefined
optionalDependencies: 8
```

So it is removed rather than migrated to `pnpm-workspace.yaml`.

## Verification

- [x] `pnpm publish --tag=latest --provenance --no-git-checks --dry-run` completes successfully with pnpm 11.17.0
- [x] A clean `pnpm install --frozen-lockfile` emits no warning, and `pnpm run check` / `build` / `check:package` all pass

## After merging

v5.13.0 has been tagged and released on GitHub, but nothing was published to npm — the registry still shows 5.12.1 as `latest`. The release needs to be re-triggered once this is merged.

