### PR TITLE
feat: add missing translations for ra-core 5.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@bicstone/ra-language-japanese",
 	"description": "Japanese messages for react-admin",
-	"version": "5.13.0",
+	"version": "5.15.0",
 	"author": "Oishi Takanori",
 	"bugs": {
 		"url": "https://github.com/bicstone/ra-language-japanese/issues"

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ const messages: Required<TranslationMessages> = {
 			email: "メールアドレスである必要があります",
 			oneOf: "次のいずれかである必要があります: %{options}",
 			regex: "次の正規表現形式にする必要があります: %{pattern}",
+			unique: "重複しない値である必要があります",
 		},
 		saved_queries: {
 			label: "保存した検索条件",
@@ -193,6 +194,12 @@ const messages: Required<TranslationMessages> = {
 			remove_dialog_title: "検索条件を削除",
 			remove_message: "選択した保存検索条件を削除しますか？",
 			help: "検索条件を保存して、あとから同じ条件で検索できます",
+		},
+		guesser: {
+			empty: {
+				title: "表示するデータがありません",
+				message: "dataProviderを確認してください",
+			},
 		},
 		configurable: {
 			customize: "カスタマイズ",


### PR DESCRIPTION
## Summary

Adds the two message groups that were the only keys present in `ra-language-english@5.15.0` but missing here, and bumps the package version to `5.15.0` to match.

```ts
validation: {
    // ...
    unique: "重複しない値である必要があります",
},
guesser: {
    empty: {
        title: "表示するデータがありません",
        message: "dataProviderを確認してください",
    },
},
```

After this change the key sets of `ra-language-english@5.15.0` and this package match exactly (164 / 164).

## Why these were missing

- **`ra.validation.unique`** has been in `ra-language-english` since 5.0.0 and was never translated here. It is the default message of `useUnique()` (`ra-core/form/validation/useUnique.js`) and ra-core provides **no fallback text**, so users of `validate={unique()}` without a custom `message` were shown the literal string `ra.validation.unique` as a form error.
- **`ra.guesser.empty.*`** was introduced in 5.15.0 for the empty state of `<ListGuesser>` (`ra-ui-materialui/list/ListGuesser.tsx`). It is called with an `_` fallback, so the impact was limited to English text leaking into the UI during prototyping.

## Why the type checker did not catch it

`Required<TranslationMessages>` only makes the top-level `ra` property required. `ra.guesser` and `ra.configurable` are declared optional inside `ra`, so omitting `guesser` entirely still type-checks. And `unique` is not declared in ra-core's `TranslationMessages` at all — it is only accepted through the `[key: string]: StringMap | string` index signature, so it can never be caught by types.

Comparing key sets against `ra-language-english` in CI would be a more reliable guard. Happy to open a follow-up for that if it sounds useful.

## Version bump

`ra-core` was updated to 5.15.0 in #521, but the package version was left at 5.13.0. This PR aligns it with the ra-core / ra-language-english version, consistent with how previous ra-core updates bumped it.

## Notes

Related but intentionally out of scope: #542 (plural forms after `||||` are never rendered in the `ja` locale). That one changes existing user-facing wording, so it should land separately.

## Test plan

- [x] `biome check .` — clean
- [x] `tsc --noEmit` — clean
- [x] `zshy` + `scripts/fix-exports.mjs` — build succeeds, `package.json#/exports` unchanged
- [x] Key sets diffed against `ra-language-english@5.15.0` — exact match
- [ ] `check:package` (`attw` / `publint`) — left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAWaCBBV4kgy64bBZfYAb6
